### PR TITLE
show static text instead when text fits within container

### DIFF
--- a/index.js
+++ b/index.js
@@ -164,12 +164,12 @@ export default class MarqueeText extends PureComponent<DefaultProps, Props, Stat
     const { duration, easing, loop, onMarqueeComplete, useNativeDriver } = this.props;
 
     const callback = () => {
-      this.setState({ animating: true });
-
       this.setTimeout(() => {
         this.calculateMetrics();
 
         if (!this.contentFits) {
+          this.setState({ animating: true });
+
           Animated.timing(this.animatedValue, {
             toValue: -this.distance,
             duration: duration,
@@ -185,6 +185,11 @@ export default class MarqueeText extends PureComponent<DefaultProps, Props, Stat
               }
             }
           });
+        } else {
+          this.setTimeout(() => {
+            this.stop();
+            onMarqueeComplete();
+          }, duration)
         }
       }, 100);
     };


### PR DESCRIPTION
I faced the problem when the text fits in container width. In that case I want the text just align on center by `{textAlign: 'center'}`. However `this.setState({ animating: true });` is called even before `this.calculateMetrics();` thus the static text with center aligned opacity is set to `0` and show ScrollView instead.

This PR aims to solve this by calling `this.setState({ animating: true });` after `contentFits` is known. And if `contentFits` is true, instead of animating it, just leave it as is and call

```js
this.stop();
onMarqueeComplete();
```

after `duration` passed.

## Disclaimer

I don't actually test this because setting up environment is somehow not convenient and the paths in the `index.js` are entangled. So please test before accept or reject. If there is more time I will create PR for testing locally.