### PR TITLE
MarqueeText should extend TextProps

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -11,11 +11,12 @@ import {
   StyleProp,
   TextStyle,
   EasingFunction,
+  TextProps,
 } from 'react-native';
 
 const { UIManager } = NativeModules;
 
-export interface IMarqueeTextProps {
+export interface IMarqueeTextProps extends TextProps {
   style?: StyleProp<TextStyle>;
   duration?: number;
   easing?: EasingFunction;


### PR DESCRIPTION
MarqueeText should extend TextProps in order to accept other properties that Text accepts, like accessibilityHint.